### PR TITLE
Fix: bulk delete tasks in scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Multisite Exporter plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-05-07
+### Fixed
+- "The link you followed has expired" error when performing bulk delete operations in scheduled actions
+- PHP Fatal error "Cannot use auto-global as lexical variable" in scheduled actions page
+- "Headers already sent" warning by adding headers_sent() check before redirects
+
+### Improved
+- Error handling for bulk operations in scheduled actions
+- Added proper checkbox handling for "select all" functionality in bulk operations
+- Implemented a fallback for displaying success messages when headers are already sent
+
 ## [1.1.2] - 2025-05-07
 ### Fixed
 - Added proper error handling with WP_DEBUG checks for all error_log calls in class-init.php

--- a/multisite-exporter.php
+++ b/multisite-exporter.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Multisite Exporter
 Description: Runs WordPress Exporter on each subsite in a multisite, in the background.
-Version: 1.1.2
+Version: 1.1.3
 Author: Per Søderlind
 Author URI: https://soderlind.no
 License: GPL2
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'MULTISITE_EXPORTER_VERSION', '1.1.2' );
+define( 'MULTISITE_EXPORTER_VERSION', '1.1.3' );
 define( 'MULTISITE_EXPORTER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: multisite, export, background processing, action scheduler
 Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -108,6 +108,12 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 
 
 == Changelog ==
+
+= 1.1.3 =
+* Fixed: "The link you followed has expired" error when performing bulk delete operations
+* Fixed: PHP Fatal error "Cannot use auto-global as lexical variable" in scheduled actions page
+* Fixed: "Headers already sent" warning by adding headers_sent() check before redirects
+* Improved: Error handling for bulk operations in scheduled actions
 
 = 1.1.2 =
 * Added: Automatic plugin updates using YahnisElsts\PluginUpdateChecker


### PR DESCRIPTION
This pull request introduces version 1.1.3 of the Multisite Exporter plugin, focusing on bug fixes, improved error handling, and enhanced user experience for bulk operations in the scheduled actions page. Key changes include resolving critical errors, improving bulk operation handling, and updating version references across the plugin files.

### Bug Fixes and Error Handling:
* Fixed "The link you followed has expired" error during bulk delete operations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R17) [[2]](diffhunk://#diff-12fd15d9916ca01e39bb22a0af1f9aee944b6cda4b98b83ccc2997f2dec8c7d1R22-R92)
* Resolved PHP Fatal error "Cannot use auto-global as lexical variable" on the scheduled actions page.
* Addressed "Headers already sent" warning by adding a `headers_sent()` check before redirects. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R17) [[2]](diffhunk://#diff-12fd15d9916ca01e39bb22a0af1f9aee944b6cda4b98b83ccc2997f2dec8c7d1R22-R92)

### Bulk Operations Enhancements:
* Improved error handling for bulk operations and added proper checkbox handling for "select all" functionality. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R17) [[2]](diffhunk://#diff-12fd15d9916ca01e39bb22a0af1f9aee944b6cda4b98b83ccc2997f2dec8c7d1R152-R190)
* Implemented a fallback mechanism to display success messages when headers are already sent.
* Added support for POST-based bulk action processing, including nonce verification and custom checkbox naming. [[1]](diffhunk://#diff-12fd15d9916ca01e39bb22a0af1f9aee944b6cda4b98b83ccc2997f2dec8c7d1R272-R331) [[2]](diffhunk://#diff-12fd15d9916ca01e39bb22a0af1f9aee944b6cda4b98b83ccc2997f2dec8c7d1L168-R347)

### Version Updates:
* Updated plugin version to 1.1.3 in `multisite-exporter.php` and `readme.txt`. [[1]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L5-R5) [[2]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L21-R21) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Documented changes for version 1.1.3 in `CHANGELOG.md` and `readme.txt`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R17) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R112-R117)