### PR TITLE
Enhance pagination text display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Multisite Exporter plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2025-05-14
+### Fixed
+- Fixed: Only show "across all pages" text when there are multiple pages of results.
+
 ## [1.1.7] - 2025-05-14
 ### Added
 - Conditional display of pagination text for selected exports: now shows "across all pages" only when there is more than one page of results.

--- a/includes/admin/views/view-history-page.php
+++ b/includes/admin/views/view-history-page.php
@@ -199,56 +199,41 @@ $exports = array_slice( $all_exports, $offset, $per_page );
 					<a href="#" class="button"
 						id="deselect-all"><?php esc_html_e( 'Deselect All', 'multisite-exporter' ); ?></a>
 				</div>
-
-				<div id="select-all-pages-notice" class="alignleft hidden"
-					style="margin-left: 10px; padding: 5px; background-color: #f7f7f7; border: 1px solid #ccc; display: none;">
-					<span>
-						<?php
-						printf(
-							/* translators: %1$d: Number of items on current page, %2$d: Total number of items */
-							esc_html__( 'All %1$d exports on this page are selected. ', 'multisite-exporter' ),
-							count( $exports )
-						);
-						?>
-					</span>
-					<a href="#" id="select-across-pages">
-						<?php
-						if ( $total_pages > 1 ) {
+				<?php if ( $total_pages > 1 ) : ?>
+					<div id="select-all-pages-notice" class="alignleft hidden"
+						style="margin-left: 10px; padding: 5px; background-color: #f7f7f7; border: 1px solid #ccc; display: none;">
+						<span>
+							<?php
+							printf(
+								/* translators: %1$d: Number of items on current page, %2$d: Total number of items */
+								esc_html__( 'All %1$d exports on this page are selected. ', 'multisite-exporter' ),
+								count( $exports )
+							);
+							?>
+						</span>
+						<a href="#" id="select-across-pages">
+							<?php
 							printf(
 								/* translators: %d: Total number of items */
 								esc_html__( 'Select all %d exports across all pages', 'multisite-exporter' ),
 								$total_exports
 							);
-						} else {
-							printf(
-								/* translators: %d: Total number of items */
-								esc_html__( 'Select all %d exports', 'multisite-exporter' ),
-								$total_exports
-							);
-						}
-						?>
-					</a>
-				</div>
+							?>
+						</a>
+					</div>
 
-				<div id="all-selected-notice" class="alignleft hidden"
-					style="margin-left: 10px; padding: 5px; background-color: #f7f7f7; border: 1px solid #ccc; display: none;">
-					<?php
-					if ( $total_pages > 1 ) {
+					<div id="all-selected-notice" class="alignleft hidden"
+						style="margin-left: 10px; padding: 5px; background-color: #f7f7f7; border: 1px solid #ccc; display: none;">
+						<?php
 						printf(
 							/* translators: %d: Total number of items */
 							esc_html__( 'All %d exports across all pages are selected. ', 'multisite-exporter' ),
 							$total_exports
 						);
-					} else {
-						printf(
-							/* translators: %d: Total number of items */
-							esc_html__( 'All %d exports are selected. ', 'multisite-exporter' ),
-							$total_exports
-						);
-					}
-					?>
-					<a href="#" id="clear-selection"><?php esc_html_e( 'Clear selection', 'multisite-exporter' ); ?></a>
-				</div>
+						?>
+						<a href="#" id="clear-selection"><?php esc_html_e( 'Clear selection', 'multisite-exporter' ); ?></a>
+					</div>
+				<?php endif; ?>
 
 				<?php if ( $total_pages > 1 ) : ?>
 					<?php me_output_pagination( $current_page, $total_pages, $total_exports ); ?>

--- a/multisite-exporter.php
+++ b/multisite-exporter.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Multisite Exporter
 Description: Runs WordPress Exporter on each subsite in a multisite, in the background.
-Version: 1.1.7
+Version: 1.1.8
 Author: Per Søderlind
 Author URI: https://soderlind.no
 License: GPL2
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'MULTISITE_EXPORTER_VERSION', '1.1.7' );
+define( 'MULTISITE_EXPORTER_VERSION', '1.1.8' );
 define( 'MULTISITE_EXPORTER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: multisite, export, background processing, action scheduler
 Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -108,6 +108,9 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 
 
 == Changelog ==
+
+= 1.1.8 =
+* Fixed: Only show "across all pages" text when there are multiple pages of results.
 
 = 1.1.7 =
 * Improved: Conditional display of pagination text for selected exports: now shows "across all pages" only when there is more than one page of results


### PR DESCRIPTION
This pull request updates the Multisite Exporter plugin to version 1.1.8, introducing a bug fix to ensure that the "across all pages" text is only displayed when there are multiple pages of results. The changes include updates to the plugin version, the changelog, and the logic for displaying pagination-related text in the admin interface.

### Bug Fixes:
* Updated the logic in `includes/admin/views/view-history-page.php` to conditionally display "across all pages" text only when there are multiple pages of results, simplifying the code and avoiding unnecessary duplication. [[1]](diffhunk://#diff-e694ef79c614f92de435b408047ddac4b408fff57a9a839b8e89dfa68686f666L202-R202) [[2]](diffhunk://#diff-e694ef79c614f92de435b408047ddac4b408fff57a9a839b8e89dfa68686f666L216-R236)

### Version Updates:
* Incremented the plugin version to 1.1.8 in `multisite-exporter.php` and updated the `MULTISITE_EXPORTER_VERSION` constant to match. [[1]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L5-R5) [[2]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L21-R21)
* Updated the `Stable tag` in `readme.txt` to reflect the new version.

### Documentation:
* Added a new entry for version 1.1.8 in the `CHANGELOG.md` and `readme.txt` files, documenting the fix for the "across all pages" text display issue. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R112-R114)