### PR TITLE
Add WP CLI support and update documentation for version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Multisite Exporter plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-05-14 
+### Added
+- WP CLI command for exporting content from multisite installations
+- Command line progress bar during export
+- Export content filtering by post types (posts, pages, media)
+- Option to select specific site IDs for export
+- Automatic creation of zip file when exporting multiple sites
+
 ## [1.1.8] - 2025-05-14
 ### Fixed
 - Fixed: Only show "across all pages" text when there are multiple pages of results.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://github.com/user-attachments/assets/172e2f69-3ea1-443d-b46f-fcdc82e11db4
 
 ## Usage
 
-### Running an Export
+### Running an Export (UI Method)
 
 1. Log in to your WordPress Network Admin dashboard
 2. Navigate to MS Exporter → Multisite Exporter
@@ -52,7 +52,7 @@ https://github.com/user-attachments/assets/172e2f69-3ea1-443d-b46f-fcdc82e11db4
 4. Click "Run Export for All Subsites"
 5. Exports will be processed in the background using Action Scheduler
 
-### Accessing Export Files
+### Accessing Export Files (UI Method)
 
 1. Navigate to MS Exporter → Exports
 2. View a list of all completed exports from all subsites
@@ -60,6 +60,50 @@ https://github.com/user-attachments/assets/172e2f69-3ea1-443d-b46f-fcdc82e11db4
    - Click the "Download" button next to an individual export
    - Select multiple exports using checkboxes and click "Download Selected" to get a zip file
    - Use "Select All" and "Download Selected" to download all exports at once in a zip file.
+   
+### WP CLI Method
+
+The plugin includes a WP CLI command to export content directly from the command line.
+
+#### Basic Export (All Sites, All Content)
+
+```
+wp multisite-exporter export
+```
+
+This will export all content from all sites in your multisite network.
+
+#### Exporting Specific Content Types
+
+```
+wp multisite-exporter export --content=posts,pages
+```
+
+Valid content types are: all, posts, pages, media
+
+#### Exporting Specific Sites
+
+```
+wp multisite-exporter export --site_ids=1,2,3
+```
+
+This will export only the sites with the specified IDs.
+
+#### Filtering by Date Range
+
+```
+wp multisite-exporter export --start_date=2023-01-01 --end_date=2023-12-31
+```
+
+#### Full Example
+
+```
+wp multisite-exporter export --site_ids=1,2,3 --content=posts,pages --start_date=2023-01-01
+```
+
+The command will display a progress bar during export. When completed:
+- For a single site, the export file will be saved in your current directory
+- For multiple sites, a zip file containing all exports will be created in your current directory
 
 ## How Action Scheduler Works
 

--- a/includes/class-multisite-exporter.php
+++ b/includes/class-multisite-exporter.php
@@ -89,6 +89,11 @@ class Multisite_Exporter {
 		if ( is_admin() ) {
 			include_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/admin/class-admin.php';
 		}
+
+		// CLI includes
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			include_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/cli/class-cli.php';
+		}
 	}
 
 	/**
@@ -125,6 +130,11 @@ class Multisite_Exporter {
 		}
 
 		ME_Export::instance();
+
+		// Initialize CLI commands if in WP CLI context
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			ME_CLI::instance();
+		}
 	}
 
 	/**

--- a/includes/cli/class-cli.php
+++ b/includes/cli/class-cli.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WP CLI integration.
+ *
+ * @since      1.2.0
+ * @package    Multisite_Exporter
+ * @subpackage Multisite_Exporter/CLI
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WP CLI integration class.
+ */
+class ME_CLI {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @since  1.2.0
+	 * @var    ME_CLI
+	 */
+	protected static $_instance = null;
+
+	/**
+	 * Main ME_CLI Instance.
+	 *
+	 * @return ME_CLI - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init_hooks();
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	private function init_hooks() {
+		// Only register WP CLI commands when WP CLI is available
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$this->register_commands();
+		}
+	}
+
+	/**
+	 * Register WP CLI commands.
+	 */
+	private function register_commands() {
+		require_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/cli/class-me-cli-command.php';
+		WP_CLI::add_command( 'multisite-exporter', 'ME_CLI_Command' );
+	}
+}

--- a/includes/cli/class-me-cli-command.php
+++ b/includes/cli/class-me-cli-command.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * WP CLI Commands for Multisite Exporter
+ *
+ * @since      1.2.0
+ * @package    Multisite_Exporter
+ * @subpackage Multisite_Exporter/CLI
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Multisite Exporter CLI commands.
+ */
+class ME_CLI_Command extends WP_CLI_Command {
+
+	/**
+	 * Exports content from one or more sites in a multisite network.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--site_ids=<ids>]
+	 * : Comma-separated list of site IDs to export. Default is all sites.
+	 *
+	 * [--content=<content_types>]
+	 * : Comma-separated list of content types to export: all, posts, pages, media. Default is 'all'.
+	 * 
+	 * [--start_date=<date>]
+	 * : Optional start date for filtering content in YYYY-MM-DD format.
+	 *
+	 * [--end_date=<date>]
+	 * : Optional end date for filtering content in YYYY-MM-DD format.
+	 * 
+	 * ## EXAMPLES
+	 *
+	 *     # Export all content from all sites
+	 *     $ wp multisite-exporter export
+	 *
+	 *     # Export only posts and pages from sites with IDs 1, 2, and 3
+	 *     $ wp multisite-exporter export --site_ids=1,2,3 --content=posts,pages
+	 *
+	 *     # Export all content from all sites created after a specific date
+	 *     $ wp multisite-exporter export --start_date=2023-01-01
+	 * 
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function export( $args, $assoc_args ) {
+		// Check if we're running in a multisite environment
+		if ( ! is_multisite() ) {
+			WP_CLI::error( 'This command can only be run on a multisite installation.' );
+			return;
+		}
+
+		// Parse arguments
+		$site_ids      = isset( $assoc_args[ 'site_ids' ] ) ? explode( ',', $assoc_args[ 'site_ids' ] ) : array();
+		$content_types = isset( $assoc_args[ 'content' ] ) ? explode( ',', $assoc_args[ 'content' ] ) : array( 'all' );
+		$start_date    = isset( $assoc_args[ 'start_date' ] ) ? $assoc_args[ 'start_date' ] : null;
+		$end_date      = isset( $assoc_args[ 'end_date' ] ) ? $assoc_args[ 'end_date' ] : null;
+
+		// Validate content types
+		$valid_content_types = array( 'all', 'posts', 'pages', 'media' );
+		foreach ( $content_types as $type ) {
+			if ( ! in_array( $type, $valid_content_types, true ) ) {
+				WP_CLI::error( sprintf( 'Invalid content type: %s. Valid types are: %s', $type, implode( ', ', $valid_content_types ) ) );
+				return;
+			}
+		}
+
+		// Get all sites or specific sites
+		if ( empty( $site_ids ) ) {
+			$sites = get_sites( array( 'number' => 0 ) );
+		} else {
+			$sites = array();
+			foreach ( $site_ids as $site_id ) {
+				$site = get_site( $site_id );
+				if ( $site ) {
+					$sites[] = $site;
+				} else {
+					WP_CLI::warning( sprintf( 'Site with ID %s not found.', $site_id ) );
+				}
+			}
+
+			if ( empty( $sites ) ) {
+				WP_CLI::error( 'No valid sites found with the provided IDs.' );
+				return;
+			}
+		}
+
+		// Set up export arguments
+		$export_args = array(
+			'content'    => $content_types,
+			'start_date' => $start_date,
+			'end_date'   => $end_date,
+		);
+
+		// Create directory to store exports if not exists
+		$init       = ME_Init::instance();
+		$export_dir = $init->get_export_directory();
+
+		WP_CLI::log( sprintf( 'Exporting content from %d site(s)...', count( $sites ) ) );
+
+		// Set up a progress bar
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Exporting sites', count( $sites ) );
+
+		$export_files = array();
+
+		// Process each site
+		foreach ( $sites as $site ) {
+			$blog_id = $site->blog_id;
+
+			// Switch to the site being exported
+			switch_to_blog( $blog_id );
+
+			// Get site information
+			$site_name           = get_bloginfo( 'name' );
+			$sanitized_site_name = sanitize_title( $site_name );
+
+			WP_CLI::log( sprintf( 'Exporting %s (ID: %d)...', $site_name, $blog_id ) );
+
+			// Generate export file name
+			$file_name = 'export-blog-' . $blog_id . '-' . $sanitized_site_name . '-' . date( 'Ymd-His' ) . '.xml';
+			$file_path = trailingslashit( $export_dir ) . $file_name;
+
+			// Generate export content
+			$exporter       = ME_Export::instance();
+			$export_content = $exporter->generate_export( $export_args );
+
+			// Save export file
+			global $wp_filesystem;
+
+			// Initialize filesystem if needed
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+
+			if ( ! WP_Filesystem() ) {
+				WP_CLI::error( 'Unable to initialize WordPress filesystem.' );
+				restore_current_blog();
+				return;
+			}
+
+			if ( ! $wp_filesystem->put_contents( $file_path, $export_content, FS_CHMOD_FILE ) ) {
+				WP_CLI::error( sprintf( 'Failed to save export file for site %s (ID: %d).', $site_name, $blog_id ) );
+				restore_current_blog();
+				continue;
+			}
+
+			// Add file to our list of exports
+			$export_files[] = array(
+				'blog_id'   => $blog_id,
+				'site_name' => $site_name,
+				'file_path' => $file_path,
+				'file_name' => $file_name,
+			);
+
+			// Restore to the previous blog
+			restore_current_blog();
+
+			// Advance the progress bar
+			$progress->tick();
+		}
+
+		$progress->finish();
+
+		// Check if we have any successful exports
+		if ( empty( $export_files ) ) {
+			WP_CLI::error( 'No exports were generated.' );
+			return;
+		}
+
+		// Handle outputs based on the number of sites
+		if ( count( $export_files ) === 1 ) {
+			// Single site export - copy file to current directory
+			$current_dir = getcwd();
+			$destination = trailingslashit( $current_dir ) . $export_files[ 0 ][ 'file_name' ];
+
+			if ( ! copy( $export_files[ 0 ][ 'file_path' ], $destination ) ) {
+				WP_CLI::error( 'Failed to save export file to the current directory.' );
+				return;
+			}
+
+			WP_CLI::success( sprintf( 'Export successful! File saved to: %s', $destination ) );
+		} else {
+			// Multiple sites - create zip file
+			$current_dir  = getcwd();
+			$zip_filename = 'multisite-export-' . date( 'Ymd-His' ) . '.zip';
+			$zip_path     = trailingslashit( $current_dir ) . $zip_filename;
+
+			WP_CLI::log( 'Creating zip archive...' );
+
+			$zip = new ZipArchive();
+			if ( $zip->open( $zip_path, ZipArchive::CREATE ) !== true ) {
+				WP_CLI::error( 'Failed to create ZIP file.' );
+				return;
+			}
+
+			// Add files to the zip
+			foreach ( $export_files as $export ) {
+				if ( file_exists( $export[ 'file_path' ] ) ) {
+					$zip->addFile( $export[ 'file_path' ], $export[ 'file_name' ] );
+				} else {
+					WP_CLI::warning( sprintf( 'File not found: %s', $export[ 'file_path' ] ) );
+				}
+			}
+
+			$zip->close();
+
+			if ( ! file_exists( $zip_path ) ) {
+				WP_CLI::error( 'Failed to create ZIP file.' );
+				return;
+			}
+
+			WP_CLI::success( sprintf( 'Export successful! %d sites exported to: %s', count( $export_files ), $zip_path ) );
+		}
+	}
+}

--- a/multisite-exporter.php
+++ b/multisite-exporter.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Multisite Exporter
 Description: Runs WordPress Exporter on each subsite in a multisite, in the background.
-Version: 1.1.8
+Version: 1.2.0
 Author: Per Søderlind
 Author URI: https://soderlind.no
 License: GPL2
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'MULTISITE_EXPORTER_VERSION', '1.1.8' );
+define( 'MULTISITE_EXPORTER_VERSION', '1.2.0' );
 define( 'MULTISITE_EXPORTER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Multisite Exporter ===
 Contributors: persoderlind
-Tags: multisite, export, background processing, action scheduler
+Tags: multisite, export, background processing, action scheduler, wp-cli
 Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.1.8
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -43,7 +43,7 @@ Multisite Exporter is a powerful tool for WordPress multisite administrators who
 
 == Usage ==
 
-= Running an Export =
+= Running an Export (UI Method) =
 
 1. Navigate to MS Exporter → Multisite Exporter in your Network Admin dashboard
 2. Configure your export settings:
@@ -53,7 +53,7 @@ Multisite Exporter is a powerful tool for WordPress multisite administrators who
 3. Click "Run Export for All Subsites"
 4. Exports will be processed in the background using Action Scheduler
 
-= Accessing Export Files =
+= Accessing Export Files (UI Method) =
 
 1. Navigate to MS Exporter → Export History
 2. View a list of all completed exports from all subsites
@@ -61,6 +61,21 @@ Multisite Exporter is a powerful tool for WordPress multisite administrators who
    * Click the "Download" button next to an individual export
    * Select multiple exports using checkboxes and click "Download Selected" to get a zip file
    * Use "Select All" and "Download Selected" to download all exports at once
+
+= Using WP CLI Commands =
+
+The plugin includes a WP CLI command to export content directly from the command line:
+
+`wp multisite-exporter export [--site_ids=<ids>] [--content=<content_types>] [--start_date=<date>] [--end_date=<date>]`
+
+Examples:
+
+* Export all content from all sites: `wp multisite-exporter export`
+* Export specific content types: `wp multisite-exporter export --content=posts,pages`
+* Export from specific sites: `wp multisite-exporter export --site_ids=1,2,3`
+* Export with date filtering: `wp multisite-exporter export --start_date=2023-01-01`
+
+The export file(s) will be saved in your current working directory.
 
 = Customizing Export Directory =
 
@@ -108,6 +123,14 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 
 
 == Changelog ==
+
+= 1.2.0 =
+* Added: WP CLI command for exporting content from multisite installations
+* Added: Command line progress bar during export
+* Added: Export content filtering by post types (posts, pages, media)
+* Added: Option to select specific site IDs for export
+* Added: Automatic creation of zip file when exporting multiple sites
+* Enhanced: Updated documentation with detailed WP CLI usage examples
 
 = 1.1.8 =
 * Fixed: Only show "across all pages" text when there are multiple pages of results.
@@ -186,6 +209,9 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 * Full internationalization support with POT file
 
 == Upgrade Notice ==
+
+= 1.2.0 =
+Added WP CLI command for exporting content directly from the command line with progress bar.
 
 = 1.1.7 =
 Added export status tracking with real-time progress indicators and automatic redirects when exports complete.


### PR DESCRIPTION
This pull request introduces version 1.2.0 of the Multisite Exporter plugin, adding significant new functionality, including WP CLI support for command-line exports, improved export filtering options, and automatic zip file creation for multiple site exports. It also updates documentation to reflect these changes.

### New Features and Enhancements:

* **WP CLI Integration**:
  - Added a new WP CLI command (`wp multisite-exporter export`) to export content directly via the command line, with options for filtering by site IDs, content types, and date ranges. A progress bar is displayed during exports, and results are saved as individual files or zipped archives. (`includes/class-multisite-exporter.php` [[1]](diffhunk://#diff-a4bf5e0ffa8350b9063c060c9defd1d86c9d73f77b8d7dd6e8f92b3983027f34R92-R96) [[2]](diffhunk://#diff-a4bf5e0ffa8350b9063c060c9defd1d86c9d73f77b8d7dd6e8f92b3983027f34R133-R137); `includes/cli/class-cli.php` [[3]](diffhunk://#diff-3a1c8d284b38cc4a4df3f562e27c16df2631ff8c28e405ddfa51bd7b14476660R1-R64); `includes/cli/class-me-cli-command.php` [[4]](diffhunk://#diff-21f35bb2f4a5c0aed0876eafe5b9afad8b84c0bb41124e1f896ae0d4f85b06a9R1-R220)
  
* **Export Filtering and Automation**:
  - Added support for filtering export content by post types (e.g., posts, pages, media) and selecting specific site IDs for export. Automatic zip file creation is now enabled when exporting multiple sites. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R14) `readme.txt` [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R127-R134)

### Documentation Updates:

* **Usage Instructions**:
  - Updated the `README.md` and `readme.txt` files to include detailed instructions for the new WP CLI functionality, alongside examples for various export scenarios. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64-R107) `readme.txt` [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R65-R79)

### Version and Metadata Updates:

* **Version Bump**:
  - Updated the plugin version to 1.2.0 in `multisite-exporter.php` and `readme.txt`. (`multisite-exporter.php` [[1]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L5-R5) [[2]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L21-R21); `readme.txt` [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L3-R7)

These changes significantly enhance the functionality and usability of the Multisite Exporter plugin, particularly for developers and administrators who prefer command-line tools.