### PR TITLE
Bump version to 1.2.2, update changelog, and add WP-CLI package support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Multisite Exporter plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2025-05-14
+### Added
+- Support for installing WP-CLI commands as a package with `wp package install`
+
 ## [1.2.1] - 2025-05-14
 ### Fixed
 - Minor version update

--- a/command.php
+++ b/command.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Multisite Exporter WP-CLI Package
+ *
+ * @package Multisite_Exporter
+ * @since 1.2.2
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+// Check if the command is already registered (in case the plugin is loaded normally)
+if ( ! class_exists( 'ME_CLI_Command' ) ) {
+	// Define constants if they don't exist (when installed as a package)
+	if ( ! defined( 'MULTISITE_EXPORTER_PLUGIN_DIR' ) ) {
+		define( 'MULTISITE_EXPORTER_PLUGIN_DIR', __DIR__ . '/' );
+	}
+
+	// Include the necessary CLI command file
+	if ( file_exists( __DIR__ . '/includes/cli/class-me-cli-command.php' ) ) {
+		require_once __DIR__ . '/includes/cli/class-me-cli-command.php';
+	}
+
+	// Include export functions if needed
+	if ( file_exists( __DIR__ . '/includes/export/class-export.php' ) ) {
+		require_once __DIR__ . '/includes/export/class-export.php';
+	}
+
+	if ( file_exists( __DIR__ . '/includes/export/class-wxr-validator.php' ) ) {
+		require_once __DIR__ . '/includes/export/class-wxr-validator.php';
+	}
+
+	// Register the command
+	if ( class_exists( 'ME_CLI_Command' ) ) {
+		WP_CLI::add_command( 'multisite-exporter', 'ME_CLI_Command' );
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
 		"wordpress",
 		"plugin",
 		"multisite",
-		"exporter"
+		"exporter",
+		"wp-cli",
+		"wp-cli-package"
 	],
 	"license": "GPL-2.0-or-later",
 	"authors": [
@@ -30,5 +32,16 @@
 		"files": [
 			"multisite-exporter.php"
 		]
+	},
+	"extra": {
+		"commands": [
+			"multisite-exporter"
+		],
+		"bundled": false,
+		"wp-cli": {
+			"require-wp": true,
+			"require-wp-multisite": true,
+			"command": "multisite-exporter"
+		}
 	}
 }

--- a/multisite-exporter.php
+++ b/multisite-exporter.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Multisite Exporter
 Description: Runs WordPress Exporter on each subsite in a multisite, in the background.
-Version: 1.2.1
+Version: 1.2.2
 Author: Per Søderlind
 Author URI: https://soderlind.no
 License: GPL2
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'MULTISITE_EXPORTER_VERSION', '1.2.1' );
+define( 'MULTISITE_EXPORTER_VERSION', '1.2.2' );
 define( 'MULTISITE_EXPORTER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: multisite, export, background processing, action scheduler, wp-cli
 Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -123,6 +123,9 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 
 
 == Changelog ==
+
+= 1.2.2 =
+* Added: Support for installing WP-CLI commands as a package with `wp package install`
 
 = 1.2.1 =
 * Fixed: Minor version update


### PR DESCRIPTION
This pull request introduces support for installing the Multisite Exporter plugin's WP-CLI commands as a package, along with necessary updates to the plugin's metadata and supporting files. The changes ensure compatibility with WP-CLI packaging requirements while maintaining backward compatibility.

### WP-CLI Package Support

* Added a new file, `command.php`, to handle WP-CLI package-specific logic, including registering the `multisite-exporter` command and loading required classes (`ME_CLI_Command`, `Export`, `WXR_Validator`).
* Updated `composer.json` to include metadata for WP-CLI packaging, such as the `commands` array and `wp-cli` configuration. Added new tags `wp-cli` and `wp-cli-package` for better discoverability. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L9-R11) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R35-R45)

### Version and Documentation Updates

* Bumped the plugin version to `1.2.2` in `multisite-exporter.php`, `readme.txt`, and `CHANGELOG.md`. [[1]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L5-R5) [[2]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L21-R21) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Updated the changelog in `readme.txt` and `CHANGELOG.md` to document the new WP-CLI package support. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R127-R129) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10)