### PR TITLE
Add GitHub updater integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Multisite Exporter plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-05-14
+### Added
+- Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
+
 ## [1.2.0] - 2025-05-14 
 ### Added
 - WP CLI command for exporting content from multisite installations

--- a/includes/class-github-plugin-updater.php
+++ b/includes/class-github-plugin-updater.php
@@ -10,6 +10,7 @@ use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
  * using the plugin-update-checker library.
  * 
  * @package Soderlind\WordPress
+ * @link https://github.com/soderlind/wordpress-plugin-gitHub-updater
  * @version 1.0.0
  * @author Per Soderlind
  * @license GPL-2.0+

--- a/includes/class-github-plugin-updater.php
+++ b/includes/class-github-plugin-updater.php
@@ -1,0 +1,146 @@
+<?php
+namespace Soderlind\WordPress;
+
+use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
+
+/**
+ * Generic WordPress Plugin GitHub Updater
+ * 
+ * A reusable class for handling WordPress plugin updates from GitHub repositories
+ * using the plugin-update-checker library.
+ * 
+ * @package Soderlind\WordPress
+ * @version 1.0.0
+ * @author Per Soderlind
+ * @license GPL-2.0+
+ */
+class GitHub_Plugin_Updater {
+	/**
+	 * @var string GitHub repository URL
+	 */
+	private $github_url;
+
+	/**
+	 * @var string Branch to check for updates
+	 */
+	private $branch;
+
+	/**
+	 * @var string Regex pattern to match the plugin zip file name
+	 */
+	private $name_regex;
+
+	/**
+	 * @var string The plugin slug
+	 */
+	private $plugin_slug;
+
+	/**
+	 * @var string The main plugin file path
+	 */
+	private $plugin_file;
+
+	/**
+	 * @var bool Whether to enable release assets
+	 */
+	private $enable_release_assets;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param array $config Configuration array with the following keys:
+	 *                     - github_url: GitHub repository URL (required)
+	 *                     - plugin_file: Main plugin file path (required)
+	 *                     - plugin_slug: Plugin slug for updates (required)
+	 *                     - branch: Branch to check for updates (default: 'main')
+	 *                     - name_regex: Regex pattern for zip file name (optional)
+	 *                     - enable_release_assets: Whether to enable release assets (default: true if name_regex provided)
+	 */
+	public function __construct( $config = array() ) {
+		// Validate required parameters
+		$required = array( 'github_url', 'plugin_file', 'plugin_slug' );
+		foreach ( $required as $key ) {
+			if ( empty( $config[ $key ] ) ) {
+				throw new \InvalidArgumentException( "Required parameter '{$key}' is missing or empty." );
+			}
+		}
+
+		$this->github_url            = $config[ 'github_url' ];
+		$this->plugin_file           = $config[ 'plugin_file' ];
+		$this->plugin_slug           = $config[ 'plugin_slug' ];
+		$this->branch                = isset( $config[ 'branch' ] ) ? $config[ 'branch' ] : 'main';
+		$this->name_regex            = isset( $config[ 'name_regex' ] ) ? $config[ 'name_regex' ] : '';
+		$this->enable_release_assets = isset( $config[ 'enable_release_assets' ] )
+			? $config[ 'enable_release_assets' ]
+			: ! empty( $this->name_regex );
+
+		// Initialize the updater
+		add_action( 'init', array( $this, 'setup_updater' ) );
+	}
+
+	/**
+	 * Set up the update checker using GitHub integration
+	 */
+	public function setup_updater() {
+		try {
+			$update_checker = PucFactory::buildUpdateChecker(
+				$this->github_url,
+				$this->plugin_file,
+				$this->plugin_slug
+			);
+
+			$update_checker->setBranch( $this->branch );
+
+			// Enable release assets if configured
+			if ( $this->enable_release_assets && ! empty( $this->name_regex ) ) {
+				$update_checker->getVcsApi()->enableReleaseAssets( $this->name_regex );
+			}
+
+		} catch (\Exception $e) {
+			// Log error if WordPress debug is enabled
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( 'GitHub Plugin Updater Error: ' . $e->getMessage() );
+			}
+		}
+	}
+
+	/**
+	 * Create updater instance with minimal configuration
+	 * 
+	 * @param string $github_url GitHub repository URL
+	 * @param string $plugin_file Main plugin file path
+	 * @param string $plugin_slug Plugin slug
+	 * @param string $branch Branch name (default: 'main')
+	 * 
+	 * @return GitHub_Plugin_Updater
+	 */
+	public static function create( $github_url, $plugin_file, $plugin_slug, $branch = 'main' ) {
+		return new self( array(
+			'github_url'  => $github_url,
+			'plugin_file' => $plugin_file,
+			'plugin_slug' => $plugin_slug,
+			'branch'      => $branch,
+		) );
+	}
+
+	/**
+	 * Create updater instance for plugins with release assets
+	 * 
+	 * @param string $github_url GitHub repository URL
+	 * @param string $plugin_file Main plugin file path
+	 * @param string $plugin_slug Plugin slug
+	 * @param string $name_regex Regex pattern for release assets
+	 * @param string $branch Branch name (default: 'main')
+	 * 
+	 * @return GitHub_Plugin_Updater
+	 */
+	public static function create_with_assets( $github_url, $plugin_file, $plugin_slug, $name_regex, $branch = 'main' ) {
+		return new self( array(
+			'github_url'  => $github_url,
+			'plugin_file' => $plugin_file,
+			'plugin_slug' => $plugin_slug,
+			'branch'      => $branch,
+			'name_regex'  => $name_regex,
+		) );
+	}
+}

--- a/includes/class-multisite-exporter.php
+++ b/includes/class-multisite-exporter.php
@@ -54,7 +54,13 @@ class Multisite_Exporter {
 	 */
 	public function __construct() {
 		$this->includes();
-		$this->setup_updater();
+		\Soderlind\WordPress\GitHub_Plugin_Updater::create_with_assets(
+			$this->github_url,
+			MULTISITE_EXPORTER_PLUGIN_FILE,
+			'multisite-exporter',
+			'/multisite-exporter\.zip/',
+			'main'
+		);
 
 		// Check if we're running in a multisite environment
 		if ( ! is_multisite() ) {
@@ -94,20 +100,6 @@ class Multisite_Exporter {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/cli/class-cli.php';
 		}
-	}
-
-	/**
-	 * Set up the update checker using GitHub integration
-	 */
-	public function setup_updater() {
-		$update_checker = PucFactory::buildUpdateChecker(
-			$this->github_url,
-			MULTISITE_EXPORTER_PLUGIN_FILE,
-			'multisite-exporter'
-		);
-
-		$update_checker->setBranch( 'main' );
-		$update_checker->getVcsApi()->enableReleaseAssets( '/multisite-exporter\.zip/' );
 	}
 
 	/**

--- a/multisite-exporter.php
+++ b/multisite-exporter.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Multisite Exporter
 Description: Runs WordPress Exporter on each subsite in a multisite, in the background.
-Version: 1.2.0
+Version: 1.2.1
 Author: Per Søderlind
 Author URI: https://soderlind.no
 License: GPL2
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants
-define( 'MULTISITE_EXPORTER_VERSION', '1.2.0' );
+define( 'MULTISITE_EXPORTER_VERSION', '1.2.1' );
 define( 'MULTISITE_EXPORTER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'MULTISITE_EXPORTER_PLUGIN_FILE', __FILE__ );
@@ -31,9 +31,12 @@ if ( file_exists( $action_scheduler_file ) ) {
 
 require_once MULTISITE_EXPORTER_PLUGIN_DIR . 'vendor/autoload.php';
 
+// Include plugin updater
+if ( ! class_exists( 'Soderlind\WordPress\GitHub_Plugin_Updater' ) ) {
+	require_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/class-github-plugin-updater.php';
+}
 // Include the main plugin class
 require_once MULTISITE_EXPORTER_PLUGIN_DIR . 'includes/class-multisite-exporter.php';
-
 /**
  * Returns the main instance of Multisite_Exporter.
  *

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Multisite Exporter ===
 Contributors: persoderlind
 Tags: multisite, export, background processing, action scheduler, wp-cli
-Requires at least: 6.3
+Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 8.2
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -129,6 +129,10 @@ Yes, you can use the `multisite_exporter_directory` filter to specify a custom d
 
 
 == Changelog ==
+
+= 1.2.1 =
+* Use generic [WordPress Plugin GitHub Updater](https://github.com/soderlind/wordpress-plugin-gitHub-updater?tab=readme-ov-file#wordpress-plugin-github-updater)
+
 
 = 1.2.0 =
 * Added: WP CLI command for exporting content from multisite installations


### PR DESCRIPTION
This pull request introduces a new version (1.2.1) of the Multisite Exporter plugin with a significant refactor to integrate a generic GitHub Plugin Updater for handling updates. It also includes minor version bumps and documentation updates. Below are the most important changes:

### Integration of GitHub Plugin Updater:
* Added a new reusable class, `GitHub_Plugin_Updater`, to handle WordPress plugin updates from GitHub repositories using the plugin-update-checker library. (`includes/class-github-plugin-updater.php`)
* Replaced the custom `setup_updater` method in `class-multisite-exporter.php` with the new `GitHub_Plugin_Updater::create_with_assets` method. (`includes/class-multisite-exporter.php`) [[1]](diffhunk://#diff-a4bf5e0ffa8350b9063c060c9defd1d86c9d73f77b8d7dd6e8f92b3983027f34L57-R63) [[2]](diffhunk://#diff-a4bf5e0ffa8350b9063c060c9defd1d86c9d73f77b8d7dd6e8f92b3983027f34L99-L112)

### Version Updates:
* Updated the plugin version to 1.2.1 in `multisite-exporter.php` and `readme.txt`. (`multisite-exporter.php`, `readme.txt`) [[1]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L5-R5) [[2]](diffhunk://#diff-dca75b114b1895a349d0833c35e18377750db53cb35886da787d5f40d5c4b744L21-R21) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R7)
* Adjusted the "Requires at least" WordPress version to 6.5 in the plugin's metadata. (`readme.txt`)

### Documentation:
* Added a changelog entry for version 1.2.1 in `CHANGELOG.md` and `readme.txt`, documenting the use of the GitHub Plugin Updater. (`CHANGELOG.md`, `readme.txt`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R133-R136)

### Codebase Maintenance:
* Included the `GitHub_Plugin_Updater` class in the main plugin file to ensure it is loaded. (`multisite-exporter.php`)